### PR TITLE
404ページを白文字にする

### DIFF
--- a/src/app/not-found.module.css
+++ b/src/app/not-found.module.css
@@ -1,0 +1,7 @@
+.container {
+  display: flex;
+  height: 100vh;
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,7 @@
+import styles from './not-found.module.css'
+
+const Custom404 = () => {
+  return <div className={styles.container}>404 - Page Not Found</div>
+}
+
+export default Custom404


### PR DESCRIPTION
## 概要

デフォルトの404ページはダークモード時に白文字になって見えないので、カスタム404ページを作る。

- https://github.com/diawel/spoon/issues/12

## 変更点

- not-foundページを追加した

## スクリーンショット

<img width="1128" alt="スクリーンショット 2023-12-12 13 22 46" src="https://github.com/diawel/spoon/assets/38136957/a3c1cea4-49c7-47a8-b618-7a3d98761080">
