### PR TITLE
PCレイアウトを調整

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,7 +7,7 @@
 html,
 body {
   max-width: 100vw;
-  overflow-x: hidden;
+  overflow: hidden;
 }
 
 a {

--- a/src/app/layout.module.css
+++ b/src/app/layout.module.css
@@ -3,6 +3,7 @@
   height: 100vh;
   width: 100%;
   justify-content: center;
+  align-items: center;
   background-color: #eeeeee;
 }
 
@@ -14,6 +15,7 @@
   @media (min-width: 480px) {
     width: 360px;
     padding: 0 8px;
+    max-height: 720px;
   }
 }
 

--- a/src/app/layout.module.css
+++ b/src/app/layout.module.css
@@ -11,11 +11,13 @@
   background-color: #ffffff;
   width: 100%;
   height: 100%;
+  box-sizing: content-box;
 
   @media (min-width: 480px) {
     width: 360px;
-    padding: 0 8px;
-    max-height: 720px;
+    padding: 48px 8px;
+    border-radius: 36px;
+    max-height: 660px;
   }
 }
 


### PR DESCRIPTION
## 概要

大きい画面で表示したときに縦長になりすぎないように調整する。

- https://github.com/diawel/spoon/issues/10
デザインの改善は含まないのでIssueはOpenのままでお願いします。

## 変更点

- アプリ領域の最大の高さを指定した
- 上下にスマホっぽい枠を追加した

## スクリーンショット

![スクリーンショット 2023-12-13 0 28 53](https://github.com/diawel/spoon/assets/38136957/0ddf2696-bcf6-42b5-b80e-b9a97bfc4b0e)
