### PR TITLE
月の表示のためのレイアウトの実装

### DIFF
--- a/src/layouts/History/Fridge/IceCell/IceCell.module.css
+++ b/src/layouts/History/Fridge/IceCell/IceCell.module.css
@@ -1,6 +1,7 @@
 .iceCellContainer {
+  position: relative;
   width: 100%;
-  padding-top: calc(100% / (50 / 64)); 
+  padding-top: calc(100% / (50 / 64));
   position: relative;
   overflow: hidden;
 }
@@ -20,4 +21,15 @@
 
 .iceCell:hover {
   cursor: pointer;
+}
+
+.month {
+  position: absolute;
+  top: 0;
+  left: 0;
+  font-size: 10px;
+  background-color: #f5f5f5;
+  width: 65%;
+  border-bottom-right-radius: 4px;
+  text-align: center;
 }

--- a/src/layouts/History/Fridge/IceCell/IceCell.tsx
+++ b/src/layouts/History/Fridge/IceCell/IceCell.tsx
@@ -16,7 +16,7 @@ const IceCell: React.FC<IceCellProps> = ({ iceCell, onIceCellTap }) => {
     <div onClick={handleTap} className={styles.iceCellContainer}>
       <div className={styles.iceCell}>
         {/* 月全体で最後の月の場合にのみ下の要素を当てる */}
-        <div className={styles.month}>{iceCell.date.getMonth()}月</div>
+        <div className={styles.month}>{iceCell.date.getMonth() + 1}月</div>
       </div>
     </div>
   )

--- a/src/layouts/History/Fridge/IceCell/IceCell.tsx
+++ b/src/layouts/History/Fridge/IceCell/IceCell.tsx
@@ -14,7 +14,10 @@ const IceCell: React.FC<IceCellProps> = ({ iceCell, onIceCellTap }) => {
 
   return (
     <div onClick={handleTap} className={styles.iceCellContainer}>
-      <div className={styles.iceCell}></div>
+      <div className={styles.iceCell}>
+        {/* 月全体で最後の月の場合にのみ下の要素を当てる */}
+        <div className={styles.month}>{iceCell.date.getMonth()}月</div>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## 概要

各月の最初に撮ったアイスのセルに対して画像のように月を表示するための月の表示を実装.

- 対象 Issue のリンク

#16 

## 変更点

- レイアウトの実装


## スクリーンショット

こうはならんけどこうなる予定
![image](https://github.com/diawel/spoon/assets/40308976/9e8a8212-f999-4161-ae16-ff6e6003f40e)
